### PR TITLE
Set a name for the console application

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ $silexApp['user.new.command'] = function () {
 };
 
 $consoleApp = new Symfony\Component\Console\Application($silexApp);
+$consoleApp->setName('My Application');
 $consoleApp->addCommands($silexApp['command.resolver']->commands());
 $consoleApp->run();
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ $silexApp['user.new.command'] = function () {
     return new Acme\DemoBundle\Command\GreetCommand();
 };
 
-$consoleApp = new Symfony\Component\Console\Application($silexApp);
+$consoleApp = new Symfony\Component\Console\Application();
 $consoleApp->setName('My Application');
 $consoleApp->addCommands($silexApp['command.resolver']->commands());
 $consoleApp->run();


### PR DESCRIPTION
This fixes the `Object of class Silex\Application could not be converted to string` error.
